### PR TITLE
feat: 매너온도 프론트엔드 반영

### DIFF
--- a/src/components/PostDetail.tsx
+++ b/src/components/PostDetail.tsx
@@ -50,6 +50,28 @@ interface PostDetailProps {
   onDeleteSuccess: () => void; // 삭제 성공 시 호출될 콜백
 }
 
+type ProfileWithMannerTemperature = {
+  mannerTemperature?: number | null;
+  mannerTemp?: number | null;
+};
+
+const formatMannerTemperature = (
+  profile?: ProfileWithMannerTemperature | null
+) => {
+  const raw =
+    profile?.mannerTemperature ?? profile?.mannerTemp ?? null;
+  const parsed =
+    typeof raw === 'number'
+      ? raw
+      : raw != null
+      ? Number(raw)
+      : null;
+
+  return typeof parsed === 'number' && Number.isFinite(parsed)
+    ? `${parsed.toFixed(1)}°C`
+    : '정보 없음';
+};
+
 export function PostDetail({
   postId,
   onJoinWorkspace,
@@ -356,7 +378,9 @@ export function PostDetail({
                       </p>
                       <div className="flex items-center gap-2 mb-2">
                         <Thermometer className="w-4 h-4 text-blue-600" />
-                        <span className="text-sm text-blue-600">36.5°C</span>
+                        <span className="text-sm text-blue-600">
+                          {formatMannerTemperature(post.writer?.profile)}
+                        </span>
                       </div>
                       <div className="flex flex-wrap gap-2">
                         {post.writer?.profile?.travelStyles?.map((style) => (
@@ -433,7 +457,11 @@ export function PostDetail({
                               </span>
                               <div className="flex items-center gap-1 text-sm text-blue-600">
                                 <Thermometer className="w-4 h-4" />
-                                <span>36.5°C</span>
+                                <span>
+                                  {formatMannerTemperature(
+                                    p.requester.profile
+                                  )}
+                                </span>
                               </div>
                             </div>
                             <div className="flex items-center gap-1">
@@ -495,7 +523,11 @@ export function PostDetail({
                               </span>
                               <div className="flex items-center gap-1 text-sm text-blue-600">
                                 <Thermometer className="w-4 h-4" />
-                                <span>36.5°C</span>
+                                <span>
+                                  {formatMannerTemperature(
+                                    request.requester.profile
+                                  )}
+                                </span>
                               </div>
                             </div>
                             <div className="flex items-center gap-1">

--- a/src/components/ProfileModal.tsx
+++ b/src/components/ProfileModal.tsx
@@ -78,7 +78,7 @@ export function ProfileModal({
     try {
       const [profileRes, writtenPostsRes, participatedPostsRes, reviewsRes] =
         await Promise.all([
-          client.get<UserProfile>(`/users/${userId}/profile`),
+          client.get<UserProfile>(`/profile/user/${userId}`),
           client.get<Post[]>(`/users/${userId}/posts`),
           client.get<Post[]>(`/users/${userId}/participations`),
           // API 응답이 POST가 아닌 GET으로 추정됩니다.
@@ -91,7 +91,7 @@ export function ProfileModal({
         participatedPostsRes.data
       );
 
-      console.log('GET /users/{userId}profile 응답', profileRes.data);
+      console.log('GET /profile/user/{userId} 응답', profileRes.data);
 
       setProfile(profileRes.data);
       setError(null);
@@ -162,6 +162,18 @@ export function ProfileModal({
     );
   }
 
+  const rawMannerTemperature =
+    profile.mannerTemperature ?? profile.mannerTemp ?? null;
+  const parsedMannerTemperature =
+    typeof rawMannerTemperature === 'number'
+      ? rawMannerTemperature
+      : rawMannerTemperature != null
+      ? Number(rawMannerTemperature)
+      : null;
+  const mannerTemperature = Number.isFinite(parsedMannerTemperature)
+    ? parsedMannerTemperature
+    : null;
+
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
@@ -229,7 +241,11 @@ export function ProfileModal({
                     <p className="text-gray-500 text-sm mb-1">매너온도</p>
                     <div className="flex items-center justify-center gap-1 text-blue-600 font-semibold">
                       <Thermometer className="w-4 h-4" />
-                      <p>36.5°C</p>
+                      <p>
+                        {mannerTemperature != null
+                          ? `${mannerTemperature.toFixed(1)}°C`
+                          : '정보 없음'}
+                      </p>
                     </div>
                   </div>
                   <div className="bg-gray-50 rounded-lg p-4 text-center">

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -11,6 +11,7 @@ interface Profile {
   mbtiTypes: string;
   travelStyles: string[];
   profileImageId: string | null;
+  mannerTemperature?: number;
 }
 
 interface User {

--- a/src/types/participation.ts
+++ b/src/types/participation.ts
@@ -8,6 +8,8 @@ export interface UserProfile {
   travelTendency: string[];
   mbtiTypes: string;
   profileImage?: string; // 프로필 이미지는 응답에 없지만, 확장성을 위해 추가
+  mannerTemperature?: number;
+  mannerTemp?: number;
 }
 
 export interface Requester {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -8,6 +8,8 @@ export interface UserProfile {
   travelStyles: string[];
   tendency: string[];
   profileImageId?: string;
+  mannerTemperature?: number;
+  mannerTemp?: number;
 }
 
 export interface User {


### PR DESCRIPTION
- profile 엔티티에 manner_temperature 컬럼을 추가해 ORM이 직접 값을 관리하도록 함

- 리뷰 생성·수정 시 별점→ΔT 매핑, 클램프, 프로필 온도 갱신을 수행하도록 서비스 로직을 확장했고, 평점 업데이트 API/DTO를 새로 노출

- 매너 온도가 NUMERIC 문자열로 들어오는 경우에도 안전하게 숫자로 변환해 NaN 문제를 방지

- 프로필 응답 DTO에 mannerTemperature 필드를 포함시켜 프론트에서 바로 사용할 수 있게 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 프로필 페이지에서 매너 온도가 동적으로 표시됩니다. 정보가 없을 경우 "정보 없음"으로 표시됩니다.

* **개선사항**
  * 프로필 데이터 조회 및 리뷰 데이터 처리 성능을 최적화했습니다.
  * 매너 온도 데이터 처리의 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->