### PR TITLE
Fix: 검색 시 페이지가 변경되는 부분 리팩토링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,30 +139,8 @@ function AllPostsPageWrapper({
   onViewPost: (postId: string) => void;
   fetchTrigger: number;
 }) {
-  const navigate = useNavigate();
-
-  const handleSearch = (params: {
-    startDate?: string;
-    endDate?: string;
-    location?: string;
-    title?: string;
-    keyword?: string;
-  }) => {
-    const searchParams = new URLSearchParams();
-    if (params.startDate) searchParams.set('startDate', params.startDate);
-    if (params.endDate) searchParams.set('endDate', params.endDate);
-    if (params.location) searchParams.set('location', params.location);
-    if (params.title) searchParams.set('title', params.title);
-    if (params.keyword) searchParams.set('keyword', params.keyword);
-    navigate(`/search?${searchParams.toString()}`);
-  };
-
   return (
-    <AllPostsPage
-      onViewPost={onViewPost}
-      onSearch={handleSearch}
-      fetchTrigger={fetchTrigger}
-    />
+    <AllPostsPage onViewPost={onViewPost} fetchTrigger={fetchTrigger} />
   );
 }
 

--- a/src/components/AllPostsPage.tsx
+++ b/src/components/AllPostsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { ClipboardList, Search, SlidersHorizontal, X } from 'lucide-react';
 import { Button } from './ui/button';
 import client from '../api/client';
@@ -7,20 +7,20 @@ import { MainPostCardSkeleton } from './AIMatchingSkeletion';
 import { WorkspaceCard } from './WorkspaceCard';
 import { useAuthStore } from '../store/authStore';
 
+type SearchParams = {
+  startDate?: string;
+  endDate?: string;
+  location?: string;
+  title?: string;
+};
+
 interface AllPostsPageProps {
   onViewPost: (postId: string) => void;
-  onSearch: (params: {
-    startDate?: string;
-    endDate?: string;
-    location?: string;
-    title?: string;
-  }) => void;
   fetchTrigger: number;
 }
 
 export function AllPostsPage({
   onViewPost,
-  onSearch,
   fetchTrigger,
 }: AllPostsPageProps) {
   const [posts, setPosts] = useState<Post[]>([]);
@@ -35,37 +35,61 @@ export function AllPostsPage({
   const [location, setLocation] = useState('');
   const filterRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (isAuthLoading) {
+  const fetchPosts = useCallback(
+    async (params?: SearchParams) => {
       setIsLoading(true);
-      return;
-    }
+      // 빈 값은 쿼리에서 제거
+      const filteredParams = params
+        ? Object.entries(params).reduce(
+            (acc, [key, value]) => {
+              if (value) acc[key as keyof SearchParams] = value;
+              return acc;
+            },
+            {} as SearchParams
+          )
+        : {};
+      const query = new URLSearchParams(
+        filteredParams as Record<string, string>
+      ).toString();
 
-    const fetchAllPosts = async () => {
-      setIsLoading(true);
+      const endpoint = query ? `/posts/search?${query}` : '/posts';
+
       try {
-        const initialPostsResponse = await client.get<Post[]>('/posts');
-
-        const sortedInitialPosts = initialPostsResponse.data.sort(
+        const response = await client.get<Post[]>(endpoint);
+        const sortedPosts = response.data.sort(
           (a, b) =>
             new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
         );
-        setPosts(sortedInitialPosts);
-        console.log(`최신 동행 글 목록`, sortedInitialPosts);
+        setPosts(sortedPosts);
+        console.log('동행 글 목록', sortedPosts);
       } catch (error) {
         console.error('Failed to fetch posts:', error);
       } finally {
         setIsLoading(false);
       }
-    };
+    },
+    []
+  );
 
-    fetchAllPosts();
-  }, [isAuthLoading, fetchTrigger]);
+  useEffect(() => {
+    if (isAuthLoading) {
+      setIsLoading(true);
+      return;
+    }
+    fetchPosts();
+  }, [isAuthLoading, fetchPosts, fetchTrigger]);
+
+  const handleSearch = (params?: SearchParams) => {
+    fetchPosts(params);
+  };
 
   const handleSearchSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (searchQuery.trim()) {
-      onSearch({ title: searchQuery });
+      handleSearch({ title: searchQuery });
+    } else {
+      // 검색어가 비어있으면 전체 목록을 다시 가져온다.
+      handleSearch();
     }
   };
 
@@ -88,7 +112,7 @@ export function AllPostsPage({
 
   // 필터 적용
   const handleApplyFilters = () => {
-    onSearch({
+    handleSearch({
       startDate: startDate || undefined,
       endDate: endDate || undefined,
       location: location || undefined,
@@ -102,6 +126,7 @@ export function AllPostsPage({
     setStartDate('');
     setEndDate('');
     setLocation('');
+    handleSearch(searchQuery ? { title: searchQuery } : undefined);
   };
 
   // 활성화된 필터 개수

--- a/src/components/AllPostsPage.tsx
+++ b/src/components/AllPostsPage.tsx
@@ -85,12 +85,10 @@ export function AllPostsPage({
 
   const handleSearchSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (searchQuery.trim()) {
-      handleSearch({ title: searchQuery });
-    } else {
-      // 검색어가 비어있으면 전체 목록을 다시 가져온다.
-      handleSearch();
-    }
+    const trimmed = searchQuery.trim();
+    // 검색어가 없으면 목록을 다시 불러오지 않는다.
+    if (!trimmed) return;
+    handleSearch({ title: trimmed });
   };
 
   // 필터 외부 클릭 시 닫기


### PR DESCRIPTION
## 🚀 작업 내용 (What's Changed)
- All-posts 검색이 `/search` 라우트로 네비게이트하면서 헤더/검색창이 재구성되던 부분을 제거
- 같은 페이지에서 API로 필터링된 목록만 갱신하도록 변경
- `src/components/AllPostsPage.tsx` (lines 10-134) 검색/필터 파라미터를 받아 `/posts` 또는 `/posts/search`를 호출하는 `fetchPosts`를 추가하고, 검색/필터/초기화 시 이 함수로 목록만 다시 불러오도록 수정
- 검색어가 비어 있으면 전체 목록을 다시 가져오지 않고 그대로 놨두도록 구현

<br>

## 🧐 작업 배경 (Background)
> 기존의 검색은 헤더와 서치바를 없애고 새로운 페이지로 이동하여 UX적으로 문제가 발생